### PR TITLE
Update README.md for Episodic Memory NLQ-VSLNet

### DIFF
--- a/NLQ/VSLNet/README.md
+++ b/NLQ/VSLNet/README.md
@@ -50,7 +50,7 @@ python main.py \
     --predictor bert \
     --mode train \
     --video_feature_dim 2304 \
-    --max_pos_len 512 \
+    --max_pos_len 128 \
     --epochs 200 \
     --fv official \
     --num_workers 64 \
@@ -64,7 +64,7 @@ python main.py \
     --predictor bert \
     --mode test \
     --video_feature_dim 2304 \
-    --max_pos_len 512 \
+    --max_pos_len 128 \
     --fv official \
     --model_dir checkpoints/
 


### PR DESCRIPTION
Changes the `max_pos_len` variable to `128` instead of `512`. #9 