### PR TITLE
Add VQ2D Quickstart Colab Notebook

### DIFF
--- a/VQ2D/README.md
+++ b/VQ2D/README.md
@@ -1,5 +1,7 @@
 # Visual Queries 2D localization
 
+Also see the [VQ2D Quickstart Colab Notebook](https://colab.research.google.com/drive/1vtVOQzLarBCspQjH5RtHZ8qzH0VZxrmZ?usp=sharing) that walks through these instructions.
+
 ## Installation instructions
 
 1. Clone the repository from [here](https://github.com/EGO4D/episodic-memory).


### PR DESCRIPTION
Adds a quickstart notebook that sets up the conda env, pre-processes annotations/clips/frames, runs an eval on a subset of VQ, and also does a small e2e training run.

Note: Meta accounts (@fb.com) don't have an access to Colab, you'll need to use a non-meta Google account to see the notebook.